### PR TITLE
Review render.yaml schedule configuration

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -49,7 +49,7 @@ services:
   - type: cron
     name: prematch-pull
     env: python
-    schedule: "0 */2 * * 5,6,7"
+    schedule: "0 */2 * * 5,6,0"
     buildCommand: pip install -r requirements.txt
     startCommand: python -m app.jobs.prematch
     envVars:


### PR DESCRIPTION
Fix invalid day of week '7' in `prematch-pull` cron schedule by changing it to '0' (Sunday).

---
<a href="https://cursor.com/background-agent?bcId=bc-2b0744fa-5602-47cd-adf8-50367ab94928">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2b0744fa-5602-47cd-adf8-50367ab94928">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

